### PR TITLE
Resolve Node/npm conflicts in installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ chmod +x install-production.sh
 sudo ./install-production.sh
 ```
 
+> **Nota**: o Node.js instalado pelo script já inclui o `npm`. Não instale o `npm` separadamente com `apt` para evitar conflitos.
+
 ## Características Principais
 
 - **Detecção Avançada**: CPF, CNPJ, RG, CEP, telefones, emails

--- a/install-production.sh
+++ b/install-production.sh
@@ -53,11 +53,18 @@ log "✓ Limpeza concluída"
 # ============================================================================
 # 2. INSTALAÇÃO DE DEPENDÊNCIAS
 # ============================================================================
+
 log "Instalando dependências do sistema..."
 
 export DEBIAN_FRONTEND=noninteractive
 apt update -qq 2>/dev/null
 apt install -y git curl build-essential postgresql postgresql-contrib redis-server nginx python3 python3-pip unzip rsync 2>/dev/null
+
+# Remover versões antigas do Node.js/npm para evitar conflitos
+if dpkg -s nodejs >/dev/null 2>&1 || dpkg -s npm >/dev/null 2>&1; then
+    warn "Removendo pacotes antigos do Node.js e npm..."
+    apt remove -y nodejs npm >/dev/null 2>&1 || true
+fi
 
 # Node.js 20
 if ! node -v 2>/dev/null | grep -q "v20"; then

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,12 @@ apt install -y curl wget gnupg2 software-properties-common apt-transport-https \
     build-essential git nginx ufw fail2ban unzip python3 python3-pip \
     python3-venv postgresql postgresql-contrib redis-server
 
+# Remover versões antigas do Node.js/npm para evitar conflitos
+if dpkg -s nodejs >/dev/null 2>&1 || dpkg -s npm >/dev/null 2>&1; then
+    info "Removendo versões antigas do Node.js e npm..."
+    apt remove -y nodejs npm >/dev/null 2>&1 || true
+fi
+
 # ============================================================================
 # 3. INSTALAÇÃO DO NODE.JS
 # ============================================================================


### PR DESCRIPTION
## Summary
- prevent conflicts by removing old `nodejs` or `npm` packages before installation
- add note in README about not installing npm separately

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e049b95c48330a7db1258542270dc