### PR TITLE
Ensure typing extensions not installed

### DIFF
--- a/install-production.sh
+++ b/install-production.sh
@@ -78,8 +78,14 @@ npm install -g tsx 2>/dev/null
 
 # Python dependencies
 info "Instalando dependências Python..."
-pip3 install --break-system-packages datafog PyPDF2 python-docx openpyxl pandas regex 2>/dev/null || \
-pip3 install datafog PyPDF2 python-docx openpyxl pandas regex 2>/dev/null
+if dpkg -s python3-typing-extensions >/dev/null 2>&1; then
+    warn "Removendo pacote python3-typing-extensions..."
+    apt remove -y python3-typing-extensions >/dev/null 2>&1 || true
+fi
+pip3 install --break-system-packages --ignore-installed typing_extensions \
+    datafog PyPDF2 python-docx openpyxl pandas regex 2>/dev/null || \
+pip3 install --ignore-installed typing_extensions \
+    datafog PyPDF2 python-docx openpyxl pandas regex 2>/dev/null
 
 log "✓ Dependências instaladas - Node: $(node -v) | NPM: $(npm -v)"
 


### PR DESCRIPTION
## Summary
- handle distro python3-typing-extensions package
- pass `--ignore-installed typing_extensions` when installing dependencies

## Testing
- `npm install`
- `npm run check` *(fails: Property errors in client and server)*

------
https://chatgpt.com/codex/tasks/task_b_684e0e0643a08330be11b76fad081859