### PR TITLE
Add HTTPS setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ sudo -u piidetector pm2 restart pii-detector
 systemctl status postgresql redis-server nginx
 ```
 
+## Habilitar HTTPS
+
+Para gerar um certificado TLS gratuito para o domínio configurado (`monster.e-ness.com.br`) utilizando o Nginx, instale o Certbot e execute a emissão:
+
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d <your-domain>
+```
+
 ## Estrutura do Projeto
 
 ```


### PR DESCRIPTION
## Summary
- document how to install Certbot and enable HTTPS for monster.e-ness.com.br

## Testing
- `npm run check` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_684e0e0790b88330aa6812d5209bb4ef