### PR TITLE
Improve typing in server code

### DIFF
--- a/server/datafog-processor.ts
+++ b/server/datafog-processor.ts
@@ -252,8 +252,8 @@ async function runBrazilianDataDetection(text: string, fileId: number): Promise<
 }
 
 async function runDataFogDetection(
-  filePath: string, 
-  patterns: any, 
+  filePath: string,
+  patterns: string[],
   customRegex?: string
 ): Promise<DetectionResult[]> {
   return new Promise((resolve) => {
@@ -504,8 +504,16 @@ function parseDataFogOutput(output: string): DetectionResult[] {
     }
     
     const results = JSON.parse(jsonContent);
-    
-    return results.map((result: any) => ({
+
+    interface RawResult {
+      type: string;
+      value: string;
+      context: string;
+      position: number;
+      riskLevel: string;
+    }
+
+    return results.map((result: RawResult) => ({
       type: result.type,
       value: result.value,
       context: result.context,

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
 import { RedisStore } from "connect-redis";
-import { createClient } from "redis";
+import { createClient, type RedisClientType } from "redis";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { sftpMonitor } from "./sftp-monitor";
@@ -11,7 +11,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
 // Redis client configuration for sessions (only in production)
-let redisClient: any = null;
+let redisClient: RedisClientType | null = null;
 
 if (process.env.NODE_ENV === 'production' && process.env.REDIS_URL) {
   redisClient = createClient({
@@ -31,7 +31,9 @@ if (process.env.NODE_ENV === 'production' && process.env.REDIS_URL) {
 }
 
 // Session configuration with Redis store for production
-const sessionConfig: any = {
+import type { SessionOptions } from "express-session";
+
+const sessionConfig: SessionOptions = {
   secret: process.env.SESSION_SECRET || 'pii-detector-secret-key-2024',
   resave: false,
   saveUninitialized: false,
@@ -63,7 +65,7 @@ app.use(session(sessionConfig));
 app.use((req, res, next) => {
   const start = Date.now();
   const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
+  let capturedJsonResponse: Record<string, unknown> | undefined = undefined;
 
   const originalResJson = res.json;
   res.json = function (bodyJson, ...args) {
@@ -100,9 +102,11 @@ app.use((req, res, next) => {
     console.warn("SFTP monitor não iniciado:", error);
   }
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    const status = (err as { status?: number; statusCode?: number }).status ||
+      (err as { status?: number; statusCode?: number }).statusCode ||
+      500;
+    const message = err instanceof Error ? err.message : "Internal Server Error";
 
     res.status(status).json({ message });
     throw err;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -433,8 +433,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const cases = await storage.getCases();
       res.json(cases);
-    } catch (error: any) {
-      res.status(500).json({ error: error.message });
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -453,8 +453,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       const newCase = await storage.createCase(result.data);
       res.status(201).json(newCase);
-    } catch (error: any) {
-      res.status(500).json({ error: error.message });
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -466,8 +466,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ error: "Case not found" });
       }
       res.json(case_);
-    } catch (error: any) {
-      res.status(500).json({ error: error.message });
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -489,8 +489,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       await storage.updateCase(id, result.data);
       const updatedCase = await storage.getCase(id);
       res.json(updatedCase);
-    } catch (error: any) {
-      res.status(500).json({ error: error.message });
+    } catch (error) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
     }
   });
 

--- a/server/semantic-classifier.ts
+++ b/server/semantic-classifier.ts
@@ -132,8 +132,16 @@ export class SemanticClassifier {
       });
 
       const result = JSON.parse(response.choices[0].message.content || '{"detections": []}');
-      
-      return (result.detections || []).map((detection: any) => ({
+
+      interface RawDetection {
+        type?: string;
+        value?: string;
+        context?: string;
+        risk_level?: string;
+        confidence?: number;
+      }
+
+      return (result.detections || []).map((detection: RawDetection) => ({
         type: detection.type || 'UNKNOWN',
         value: detection.value || '',
         context: detection.context || '',


### PR DESCRIPTION
## Summary
- replace `any` usages with explicit interfaces
- type Redis client and session configuration
- define raw detection interfaces for AI and DataFog outputs
- update error handlers to use `unknown`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_684e1a8330c48330b3389960423ee322