### PR TITLE
Handle missing OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,8 @@ sudo certbot --nginx -d <your-domain>
 - Verificação de malware
 - Headers de segurança
 - Firewall UFW configurado
+
+## OpenAI e Análise Semântica
+
+Para habilitar a etapa opcional de análise semântica, defina a variável de ambiente `OPENAI_API_KEY` com sua chave da OpenAI.
+Caso não esteja configurada, a aplicação exibirá um aviso e continuará apenas com as detecções baseadas em expressões regulares.

--- a/server/semantic-classifier.ts
+++ b/server/semantic-classifier.ts
@@ -1,7 +1,11 @@
 import OpenAI from "openai";
 
 // the newest OpenAI model is "gpt-4o" which was released May 13, 2024. do not change this unless explicitly requested by the user
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openaiApiKey = process.env.OPENAI_API_KEY;
+if (!openaiApiKey) {
+  console.warn("OPENAI_API_KEY not set. Semantic analysis is disabled.");
+}
+const openai: OpenAI | null = openaiApiKey ? new OpenAI({ apiKey: openaiApiKey }) : null;
 
 export interface SemanticDetection {
   type: string;
@@ -70,6 +74,10 @@ export class SemanticClassifier {
   }
 
   private async validateWithAI(candidate: RegexCandidate, fullText: string): Promise<{isValid: boolean, confidence: number}> {
+    if (!openai) {
+      console.warn('Skipping AI validation because OPENAI_API_KEY is not set.');
+      return { isValid: true, confidence: 0.7 };
+    }
     try {
       const contextStart = Math.max(0, candidate.position - 100);
       const contextEnd = Math.min(fullText.length, candidate.position + candidate.value.length + 100);
@@ -107,6 +115,10 @@ export class SemanticClassifier {
   }
 
   private async performSemanticAnalysis(text: string): Promise<SemanticDetection[]> {
+    if (!openai) {
+      console.warn('Skipping semantic analysis because OPENAI_API_KEY is not set.');
+      return [];
+    }
     try {
       // Truncate text if too long
       const analysisText = text.length > this.maxContextLength 


### PR DESCRIPTION
## Summary
- warn and skip semantic features when `OPENAI_API_KEY` is not defined
- document the OpenAI requirement

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_684e1a8168cc83309c37438980cb86d9