### PR TITLE
Fix CSV export quoting

### DIFF
--- a/client/src/components/reports-section.tsx
+++ b/client/src/components/reports-section.tsx
@@ -14,6 +14,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
+import { quoteCsvField } from "@shared/csv";
 import { cn } from "@/lib/utils";
 import {
   BarChart,
@@ -248,7 +249,7 @@ export default function ReportsSection() {
     const headers = Object.keys(csvData[0] || {});
     const csvContent = [
       headers.join(','),
-      ...csvData.map(row => headers.map(header => `"${row[header as keyof typeof row]}"`).join(','))
+      ...csvData.map(row => headers.map(header => quoteCsvField(row[header as keyof typeof row])).join(','))
     ].join('\n');
 
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "tsx scripts/csv-export-check.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/csv-export-check.ts
+++ b/scripts/csv-export-check.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import { quoteCsvField } from '../shared/csv.js';
+
+const rows = [
+  [1, 'foo,bar', 'He said "hello"']
+];
+
+const csv = ['ID,Value,Note',
+  ...rows.map(r => r.map(quoteCsvField).join(','))
+].join('\n');
+
+const expected = 'ID,Value,Note\n"1","foo,bar","He said ""hello"""';
+assert.strictEqual(csv, expected);
+console.log('CSV export helper works');
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { insertFileSchema, insertProcessingJobSchema, insertDetectionSchema, insertCaseSchema } from "@shared/schema";
+import { quoteCsvField } from "@shared/csv";
 import { authenticateUser, registerUser, loginSchema, registerSchema } from "./auth";
 import multer from "multer";
 import path from "path";
@@ -401,20 +402,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const files = await storage.getFiles();
       
       // CSV header
-      let csvContent = "ID,Tipo,Valor,Arquivo,Nível de Risco,Contexto,Posição,Data de Criação\n";
-      
+      let csvContent = 'ID,Tipo,Valor,Arquivo,Nível de Risco,Contexto,Posição,Data de Criação\n';
+
       // CSV data
       detections.forEach(d => {
         const file = files.find(f => f.id === d.fileId);
         const csvRow = [
-          d.id,
-          d.type,
-          `"${d.value}"`,
-          `"${file?.originalName || 'Desconhecido'}"`,
-          d.riskLevel,
-          `"${d.context || ''}"`,
-          d.position || '',
-          d.createdAt ? new Date(d.createdAt).toISOString() : ''
+          quoteCsvField(d.id),
+          quoteCsvField(d.type),
+          quoteCsvField(d.value),
+          quoteCsvField(file?.originalName || 'Desconhecido'),
+          quoteCsvField(d.riskLevel),
+          quoteCsvField(d.context || ''),
+          quoteCsvField(d.position || ''),
+          quoteCsvField(d.createdAt ? new Date(d.createdAt).toISOString() : '')
         ].join(',');
         csvContent += csvRow + '\n';
       });

--- a/shared/csv.ts
+++ b/shared/csv.ts
@@ -1,0 +1,5 @@
+export function quoteCsvField(value: unknown): string {
+  const str = String(value ?? '');
+  return '"' + str.replace(/"/g, '""') + '"';
+}
+


### PR DESCRIPTION
## Summary
- add helper `quoteCsvField` to escape quotes
- use `quoteCsvField` when generating CSV in server and client
- add a basic script to check CSV export quoting
- wire up `npm test` to run the check

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684e1a7d7c0883308a02fcedcf0d4156