### PR TITLE
Make server port configurable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ SESSION_SECRET=your-super-secret-session-key-change-this-in-production
 
 # Server Configuration
 NODE_ENV=production
+# Porta em que o servidor irá escutar (padrão 5000)
 PORT=5000
 
 # Security Settings

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ O script automaticamente:
 - **Diretório**: /home/piidetector/pii-detector
 - **Configuração**: o arquivo `.env` é gerado em `/opt/n-piidetector/.env`
 
+## Variáveis de Ambiente
+
+Algumas configurações podem ser ajustadas no arquivo `.env` gerado durante a instalação.
+
+- `PORT`: porta que o servidor Express utiliza (padrão `5000`)
+
 ## Comandos Úteis
 
 ```bash

--- a/server/index.ts
+++ b/server/index.ts
@@ -117,10 +117,9 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = 5000;
+  // Serve the app on the configured port
+  // Defaults to 5000 if PORT is not specified
+  const port = parseInt(process.env.PORT || '5000', 10);
   server.listen({
     port,
     host: "0.0.0.0",


### PR DESCRIPTION
## Summary
- read the server port from `process.env.PORT` with a default of `5000`
- explain the `PORT` variable in README
- document the variable in `.env.example`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_684e1a688100833086b404d77862271b