### PR TITLE
Add HTTPS enable script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ sudo ./install-production.sh
 
 > **Nota**: o Node.js instalado pelo script já inclui o `npm`. Não instale o `npm` separadamente com `apt` para evitar conflitos.
 
+Após a instalação, execute `./enable-https.sh` para finalizar a configuração de HTTPS. O script utiliza o domínio definido em `/opt/n-piidetector/.env` e gera automaticamente o certificado TLS com o Certbot.
+
 ## Características Principais
 
 - **Detecção Avançada**: CPF, CNPJ, RG, CEP, telefones, emails
@@ -68,11 +70,12 @@ systemctl status postgresql redis-server nginx
 
 ## Habilitar HTTPS
 
-Para gerar um certificado TLS gratuito para o domínio configurado (`monster.e-ness.com.br`) utilizando o Nginx, instale o Certbot e execute a emissão:
+Execute o script `enable-https.sh` para gerar automaticamente o certificado TLS e aplicar as regras de rate limit no Nginx:
 
 ```bash
-sudo apt install certbot python3-certbot-nginx
-sudo certbot --nginx -d <your-domain>
+sudo ./enable-https.sh              # usa o domínio do arquivo .env
+# ou especifique manualmente
+sudo ./enable-https.sh exemplo.com
 ```
 
 ## Estrutura do Projeto

--- a/enable-https.sh
+++ b/enable-https.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+DOMAIN="$1"
+
+if [ -z "$DOMAIN" ] && [ -f /opt/n-piidetector/.env ]; then
+  DOMAIN=$(grep -E '^DOMAIN=' /opt/n-piidetector/.env | cut -d '=' -f2)
+fi
+
+if [ -z "$DOMAIN" ]; then
+  echo "Usage: $0 <domain>" >&2
+  echo "Domain not provided and DOMAIN not found in /opt/n-piidetector/.env" >&2
+  exit 1
+fi
+
+# Comment out any limit_req_zone lines in default site
+if [ -f /etc/nginx/sites-enabled/default ]; then
+  sed -i '/limit_req_zone/s/^/#/' /etc/nginx/sites-enabled/default
+fi
+
+# Ensure ratelimit.conf contains desired zone
+if [ ! -f /etc/nginx/conf.d/ratelimit.conf ] || ! grep -q 'limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;' /etc/nginx/conf.d/ratelimit.conf; then
+  echo 'limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;' > /etc/nginx/conf.d/ratelimit.conf
+fi
+
+# Test nginx configuration
+nginx -t || { echo "Nginx configuration failed" >&2; exit 1; }
+
+# Install certbot packages if necessary
+install_pkgs=""
+command -v certbot >/dev/null 2>&1 || install_pkgs="certbot"
+dpkg -s python3-certbot-nginx >/dev/null 2>&1 || install_pkgs="$install_pkgs python3-certbot-nginx"
+if [ -n "$install_pkgs" ]; then
+  apt-get update
+  apt-get install -y $install_pkgs
+fi
+
+certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos --register-unsafely-without-email
+
+systemctl reload nginx || systemctl restart nginx


### PR DESCRIPTION
## Summary
- add `enable-https.sh` to handle nginx rate limiting and certbot automation
- document usage in README

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npx vitest --version` *(prompted for package installation)*

------
https://chatgpt.com/codex/tasks/task_b_684ee37eb0f88330900b5c01ed356156