### PR TITLE
Limit parallel processing in SFTP monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "multer": "^2.0.1",
         "next-themes": "^0.4.6",
         "openai": "^5.3.0",
+        "p-limit": "^5.0.0",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "react": "^18.3.1",
@@ -7448,7 +7449,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
       "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
@@ -10241,7 +10241,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
       "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.20"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.2.5",
+    "p-limit": "^5.0.0",
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",


### PR DESCRIPTION
## Summary
- process discovered SFTP files concurrently with a limit
- queue new files through the same limiter
- add `p-limit` dependency

## Testing
- `npm test` *(fails: Cannot find module 'adm-zip')*

------
https://chatgpt.com/codex/tasks/task_b_684efd2a61388330933788ffd7c4dc6b