### PR TITLE
Fix zip extraction endpoint and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
     "vite": "^5.4.14",
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "adm-zip": "^0.5.16"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -137,13 +137,31 @@ export async function registerRoutes(app: Express): Promise<Server> {
         uploadedFiles.push(savedFile);
       }
 
-      res.json({ 
+  res.json({
         message: "Arquivos enviados com sucesso",
-        files: uploadedFiles 
+        files: uploadedFiles
       });
     } catch (error) {
       console.error("Erro no upload:", error);
       res.status(500).json({ message: "Erro interno do servidor" });
+    }
+  });
+
+  // Extract zip files endpoint
+  app.post("/api/files/extract", upload.single('file'), async (req, res) => {
+    try {
+      if (!req.file) {
+        return res.status(400).json({ message: "Nenhum arquivo foi enviado" });
+      }
+
+      const extracted = await extractZipFiles(req.file.path);
+
+      const files = extracted.map(file => ({ name: path.basename(file) }));
+
+      res.json({ files });
+    } catch (error) {
+      console.error("Erro na extração:", error);
+      res.status(500).json({ message: "Erro ao extrair arquivo" });
     }
   });
 

--- a/tests/extract-zip.test.ts
+++ b/tests/extract-zip.test.ts
@@ -1,1 +1,29 @@
 
+import { beforeEach, afterEach, describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import AdmZip from 'adm-zip';
+import { extractZipFiles } from '../server/file-handler';
+
+describe('extractZipFiles', () => {
+  const tmpDir = path.join(os.tmpdir(), 'extract-test');
+  const zipPath = path.join(tmpDir, 'test.zip');
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const zip = new AdmZip();
+    zip.addFile('file.txt', Buffer.from('conteudo'));
+    zip.writeZip(zipPath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('extrai arquivos do zip', async () => {
+    const files = await extractZipFiles(zipPath);
+    const names = files.map(f => path.basename(f));
+    expect(names).toContain('file.txt');
+  });
+});


### PR DESCRIPTION
## Summary
- add missing `/api/files/extract` route
- include adm-zip in dev dependencies
- create working extractZipFiles test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f0701c22c8330aae5270f3b0aa460